### PR TITLE
Add `dpi` option into `plot_setup`; Fix an importing bug with `matplotlib.pyplot`

### DIFF
--- a/easypyplot/pdf.py
+++ b/easypyplot/pdf.py
@@ -27,6 +27,7 @@ def plot_setup(name, figsize=None, fontsize=9, font='paper', dpi=None):
     fontsize: fontsize for legends and labels.
     font: font for legends and labels, 'paper' uses Times New Roman, 'default'
     uses default, a tuple of (family, font, ...) customizes font.
+    dpi: resolution of the figure.
     """
     paper_plot(fontsize=fontsize, font=font)
     if not name.endswith('.pdf'):
@@ -47,7 +48,7 @@ def plot_teardown(pdfpage, fig=None):
 
 
 @contextmanager
-def plot_open(name, figsize=None, fontsize=9, font='paper'):
+def plot_open(name, figsize=None, fontsize=9, font='paper', dpi=None):
     """ Open a context of PDF page for plot, used for the `with` statement.
 
     name: PDF file name. If not ending with .pdf, will automatically append.
@@ -55,9 +56,10 @@ def plot_open(name, figsize=None, fontsize=9, font='paper'):
     fontsize: fontsize for legends and labels.
     font: font for legends and labels, 'paper' uses Times New Roman, 'default'
     uses default, a tuple of (family, font, ...) customizes font.
+    dpi: resolution of the figure.
     """
     pdfpage, fig = plot_setup(name, figsize=figsize, fontsize=fontsize,
-                              font=font)
+                              font=font, dpi=dpi)
     yield fig
     plot_teardown(pdfpage, fig)
 

--- a/easypyplot/pdf.py
+++ b/easypyplot/pdf.py
@@ -15,10 +15,11 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 
 from contextlib import contextmanager
 import matplotlib.backends.backend_pdf
+import matplotlib.pyplot
 
 from .format import paper_plot
 
-def plot_setup(name, figsize=None, fontsize=9, font='paper'):
+def plot_setup(name, figsize=None, fontsize=9, font='paper', dpi=None):
     """ Setup a PDF page for plot.
 
     name: PDF file name. If not ending with .pdf, will automatically append.
@@ -31,7 +32,7 @@ def plot_setup(name, figsize=None, fontsize=9, font='paper'):
     if not name.endswith('.pdf'):
         name += '.pdf'
     pdfpage = matplotlib.backends.backend_pdf.PdfPages(name)
-    fig = matplotlib.pyplot.figure(figsize=figsize)
+    fig = matplotlib.pyplot.figure(figsize=figsize, dpi=dpi)
     return pdfpage, fig
 
 


### PR DESCRIPTION
1. Using PyCharm to view the figure output by `fig.show()` gives a blurry image, setting the DPI value while creating the figure works.

2. For some platforms, importing `matplotlib` and calling `.pyplot` is not enough; see [https://stackoverflow.com/questions/14812342/matplotlib-has-no-attribute-pyplot](https://stackoverflow.com/questions/14812342/matplotlib-has-no-attribute-pyplot).